### PR TITLE
Remove CSS rule insertion, and add optional selector param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The Dreamcatcher microservice itself exposes a very simple API with 2 endpoints:
 - **width:** INTEGER - Width of browser viewport
 - **height:** INTEGER - Height of browser viewport
 - **fileName:** STRING - Name of the file as it should appear in the download
+- **selector:** STRING - The CSS selector you want to use for querying the view dimensions
 - **clipArea:** OBJECT - Define a specific area of the page to be captured for the PNG. If omitted, the entire visible area is captured
   - **x:** INTEGER
   - **y:** INTEGER
@@ -132,6 +133,7 @@ Content-Type: application/json
 - **width:** INTEGER - Width of browser viewport
 - **height:** INTEGER - Height of browser viewport
 - **fileName:** STRING - Name of the file as it should appear in the download
+- **selector:** STRING - The CSS selector you want to use for querying the view dimensions
 - **pdfOptions:** OBJECT - Same options as Electron's printToPDF function [found here](https://github.com/electron/electron/blob/v0.35.2/docs/api/web-contents.md#webcontentsprinttopdfoptions-callback)
   - **marginsType:** INTEGER - Specify the type of margins to use (0 - default, 1 - none, 2 - minimum)
   - **landscape:** BOOLEAN - Save PDF in Landscape (true - default) or Portrait (false) orientation
@@ -157,4 +159,12 @@ Content-Type: application/json
     "printSelectionOnly": false
   }
 }
+```
+
+**NOTE:** You are responsible for disabling scrollbars through CSS on the page you are rendering. This can be done by placing this style in your `<head>`:
+
+```
+<style>
+  ::-webkit-scrollbar { display: none; }
+</style>
 ```

--- a/server.js
+++ b/server.js
@@ -40,11 +40,7 @@ function generateDownloadData(opts, nightmare, callback) {
   var dataGenerationChain = nightmare
     .viewport(opts.width, opts.height)
     .goto(opts.url)
-    .wait("body")
-    .evaluate(function () {
-      var s = document.styleSheets[0];
-      s.insertRule('::-webkit-scrollbar { display: none; }');
-    });
+    .wait("body");
 
   if(opts.type === "pdf"){
     dataGenerationChain = dataGenerationChain.pdf(undefined, opts.pdfOptions);
@@ -55,12 +51,17 @@ function generateDownloadData(opts, nightmare, callback) {
 }
 
 function findElementSize (downloadOptions, nightmare, responseCallback, generateDownloadData) {
+  var selector = downloadOptions.selector || "body";
+
   nightmare
     .goto(downloadOptions.url)
     .wait("body")
-    .evaluate(function () {
-      return { width: document.querySelector("body").offsetWidth, height: document.querySelector("body").offsetHeight };
-    })
+    .evaluate(function (selector) {
+      return { 
+        width: document.querySelector(selector).offsetWidth, 
+        height: document.querySelector(selector).offsetHeight 
+      };
+    }, selector)
     .then(function (dimensions) {
       generateDownloadData(_.extend(downloadOptions, dimensions), nightmare, responseCallback)
     })
@@ -74,6 +75,7 @@ app.post("/export/pdf", function(req,res) {
       url: req.body.url,
       width: req.body.width,
       height: req.body.height,
+      selector: req.body.selector,
       pdfOptions: pdfOptions
     },
     new Nightmare({ frame: false, useContentSize: true }),
@@ -96,6 +98,7 @@ app.post("/export/png", function(req, res) {
     url: req.body.url,
     width: req.body.width,
     height: req.body.height,
+    selector: req.body.selector,
     pngClipArea: req.body.clipArea,
   };
 


### PR DESCRIPTION
The CSS rule insertion can break, so removing the scrollbar is instead delegated to the user and their style sheet.

Selector is used to replace "body" as the CSS selector used to query dimensions. It is optional, and defaults to "body".